### PR TITLE
Fix use of path API

### DIFF
--- a/lib/asset.coffee
+++ b/lib/asset.coffee
@@ -39,7 +39,7 @@ class exports.Asset extends EventEmitter
         @headers = headers
 
         # Get the extension from the url
-        @ext = pathutil.extname @url
+        @ext = if @url then pathutil.extname @url else ''
 
         # Set whether to watch or not
         @watch = options.watch


### PR DESCRIPTION
Fix to proper use of Node 6.9 path API (required for asset-rack to be compatible with Node 6.9)